### PR TITLE
Fix small bug in `datalad reschedule`

### DIFF
--- a/datalad_slurm/reschedule.py
+++ b/datalad_slurm/reschedule.py
@@ -344,7 +344,7 @@ def _rerun_as_results(dset, revrange, since, message, rev_branch, with_failed_jo
     ds_repo = dset.repo
     # Drop any leading commits that don't have a slurm run command. These would be
     # skipped anyways.
-    results = list(dropwhile(lambda r: "slurm_run_info" not in r, results))
+    results = [result for result in results if "slurm_run_info" in result]
     # now drop the results which did not run succesfully
     if not with_failed_jobs:
         results = [result for result in results if not result["job_failed"]]


### PR DESCRIPTION
While checking issue #78, I discovered an error due to the presence of the "job_failed" key in slurm run jobs. That is now solved by filtering out **all** commits without a 'slurm_run_info' key in their results dict, not just the leading commits.

This will close issue #78 