### PR TITLE
Alternative run directories feature

### DIFF
--- a/datalad_slurm/finish.py
+++ b/datalad_slurm/finish.py
@@ -289,6 +289,11 @@ def finish_cmd(
         )
         return
 
+    ds = require_dataset(
+        dataset, check_installed=True, purpose="track command outcomes"
+    )
+    ds_path = ds.path
+
     # if committing failed jobs, close_failed_jobs must be set to True
     if commit_failed_jobs:
         close_failed_jobs = True
@@ -303,10 +308,44 @@ def finish_cmd(
         )
         return
 
+
+    print("    ppp: ", results)
+    for r in results:
+        print("        ", r, " --> ", results[r] )
+    print()
+    print("    COPY BACK FILES")
+    print()
+    # check if there was an alt_dir specified at schedule or reschedule time
+    if 'slurm_run_info' in results and 'alt_dir' in results['slurm_run_info']:
+        if results['slurm_run_info']['alt_dir']:
+
+            old_pwd= results['slurm_run_info']['pwd']
+            print("    old_pwd= ", old_pwd)
+            alt_dir= results['slurm_run_info']['alt_dir'] # not '' and not None
+            print("    alt_dir= ", alt_dir)
+            inputs= results['slurm_run_info']['inputs']
+            print("    inputs= ", inputs)
+            outputs= results['slurm_run_info']['outputs'] + results['slurm_run_info']['slurm_outputs']
+            print("    outputs= ", outputs)
+
+            for o in outputs:
+                dir= op.dirname(o)
+                command=f"cp -v -r -L -u {alt_dir}/{o} {dir}/"
+                print("        run command ", command, " ... run from ", ds_path)
+                result = subprocess.run(
+                    command, shell=True, capture_output=True, text=True, cwd=ds_path # always run from the root of the repository
+                )
+                # Extract result from copy command
+                #stdout = result.stdout
+                print("            result: ", result.stdout)
+
+    print("    DONE COPYING?")
+
+
     run_message = results["run_message"]
     slurm_run_info = results["slurm_run_info"]
-    # concatenate outputs from both submission and completion
-    outputs_to_save = ensure_list(outputs) + ensure_list(slurm_run_info["outputs"])
+    # set unuion of outputs from both submission and completion
+    outputs_to_save = list( set( ensure_list(outputs) + ensure_list(slurm_run_info["outputs"]) ) )
 
     # should throw an error if user doesn't specify outputs or directory
     if not outputs_to_save:
@@ -429,6 +468,10 @@ def extract_from_db(dset, slurm_job_id):
     # Fetch the record
     record = cur.fetchone()
 
+    print("    FINISH FINISH FINISH FINISH ")
+
+    print("    iii: ", record)
+
     if not record:
         return None
 
@@ -437,17 +480,27 @@ def extract_from_db(dset, slurm_job_id):
 
     # extract as dictionary
     slurm_run_info = dict(zip(column_names, record))
+    print("    jjj: ", slurm_run_info)
 
     # convert json columns to list
     json_columns = ["chain", "inputs", "extra_inputs", "outputs", "slurm_outputs"]
 
+    print("    kkk: ", json_columns)
+
     for column in json_columns:
+        print("        kk ", column )
         slurm_run_info[column] = json.loads(slurm_run_info[column])
+
+    print("    mmm")
 
     message = slurm_run_info["message"]
     del slurm_run_info["message"]
 
+    print("    nnn")
+
     res = {"run_message": message, "slurm_run_info": slurm_run_info}
+
+    print("    ppp")
 
     return dict(res, status="ok")
 

--- a/tests/test_09_timings_very_many_jobs.sh
+++ b/tests/test_09_timings_very_many_jobs.sh
@@ -1,43 +1,68 @@
 #!/usr/bin/env bash
 
-set +e # continue on errors
+set -e # continue on errors
 
 # Test datalad 'slurm-schedule' and 'slurm-finish --list-open-jobs' and 'slurm-finish' functionality
-#   - measure how long they take with growing git log length
+#   - measure how long they take with growing number of currently scheduled jobs
+#   - do 3 different experiments at the same time, so that they see the same pressure/background noise
+#     of Slurm and of the parallel file system
 #
 # Expected results: should run without any errors
 
 
 if [[ -z $1 ]] ; then
 
-    echo "no temporary directory for tests given, abort"
+    echo "no temporary directory for this test given, abort"
     echo ""
     echo "... call as $0 <dir>"
 
     exit -1
 fi
+HERE=$1
 
-D=$1
+if [[ -z $2 ]] ; then
+
+    echo "no temporary directory for alternative execution dirs given, abort"
+    echo ""
+    echo "... call as $0 <dir>"
+
+    exit -1
+fi
+DA=$2
+
 
 # optionmal second argument for how many extra output specs should be given per job
-NUMOUTEXTRA=$2 
+NUMOUTEXTRA=$3
 if [[ -z $NUMOUTEXTRA ]] ; then
 
     NUMOUTEXTRA=0
 fi
 
-echo "start"
 
-B=`dirname $0`
+# adjust the number of jobs per type here
+TARGETS=`seq 1 11000`
 
-echo "from src dir "$B
 
-## create a test repo
+DT="datalad-slurm-test-09_"`date -Is|tr -d ":"`
+echo "start "$DT
 
-TESTDIR=$D/"datalad-slurm-test-09_"`date -Is|tr -d ":"`
+HERE=$HERE/$DT
+mkdir -p $HERE
 
-datalad create -c text2git $TESTDIR
+DA=$DA/$DT
+mkdir -p $DA
 
+## create test repos/dirs
+
+TESTDIR_D="datalad-normal-repo"
+datalad create -c text2git $HERE/$TESTDIR_D
+
+TESTDIR_S="slurm-alone-dir"
+mkdir -p $HERE/$TESTDIR_S
+
+TESTDIR_L="datalad-alt-dir"
+datalad create -c text2git $DA/$TESTDIR_L
+mkdir -p $HERE/$TESTDIR_L
 
 ### generic part for all the tests ending here, specific parts follow ###
 
@@ -46,11 +71,10 @@ if [ ! -f "slurm_config.txt" ]; then
     echo "Please see slurm_config_sample.txt for a template"
     exit -1
 fi
-
 source slurm_config.txt
 
 # Create the script
-cat <<EOF > $TESTDIR/slurm.template.sh
+cat <<EOF > $HERE/$TESTDIR_D/slurm.template.sh
 #!/bin/bash
 #SBATCH --job-name="DLtest09"         # name of the job
 #SBATCH --partition=defq              # partition to be used (defq, gpu or intel)
@@ -60,7 +84,7 @@ cat <<EOF > $TESTDIR/slurm.template.sh
 #SBATCH --cpus-per-task=1             # number of tasks per node
 #SBATCH --output=log.slurm-%j.out
 echo "started"
-OUTPUT="output_test_"\$(date -Is|tr -d ":").txt
+OUTPUT="output_test.txt"
 # simulate some text output
 for i in \$(seq 1 20); do
    echo \$i | tee -a \$OUTPUT
@@ -71,13 +95,17 @@ bzip2 -k \$OUTPUT
 echo "ended"
 EOF
 
+cp $HERE/$TESTDIR_D/slurm.template.sh $HERE/$TESTDIR_S/
+cp $HERE/$TESTDIR_D/slurm.template.sh $DA/$TESTDIR_L/
+
 # Make the script executable
-chmod u+x $TESTDIR/slurm.template.sh
+chmod u+x $HERE/$TESTDIR_D/slurm.template.sh
+chmod u+x $HERE/$TESTDIR_S/slurm.template.sh
+chmod u+x $DA/$TESTDIR_L/slurm.template.sh
 
-cd $TESTDIR
-echo "PWD "$PWD
 
-TARGETS=`seq 1 10000`
+### from here on we are inside $HERE
+cd $HERE
 
 echo "Create jobs:"
 for i in $TARGETS ; do
@@ -87,37 +115,40 @@ for i in $TARGETS ; do
     echo $M/$i
 
     DIR="$M/test_09_output_dir_$i"
-    mkdir -p $DIR.datalad $DIR.slurm
+    mkdir -p $TESTDIR_D/$DIR/
+    mkdir -p $TESTDIR_S/$DIR/
+    mkdir -p $DA/$TESTDIR_L/$DIR/
 
-    cp slurm.template.sh $DIR.datalad/slurm.sh
-    cp slurm.template.sh $DIR.slurm/slurm.sh
+    cp $TESTDIR_D/slurm.template.sh $TESTDIR_D/$DIR/slurm.sh
+    cp $TESTDIR_S/slurm.template.sh $TESTDIR_S/$DIR/slurm.sh
+    cp $DA/$TESTDIR_L/slurm.template.sh $DA/$TESTDIR_L/$DIR/slurm.sh
 
-    if [[ 0 == $M ]]; then
-
-        echo "################################################################"
-        echo "PWD "$PWD
-        echo datalad save -m "add test job dirs and scripts"
-        datalad save -m "add test job dirs and scripts"
-        echo "################################################################"
-
-    fi
 done
 
+cd $TESTDIR_D
 echo "################################################################"
 echo "PWD "$PWD
 echo datalad save -m "add test job dirs and scripts"
 datalad save -m "add test job dirs and scripts"
 echo "################################################################"
+cd $HERE
+
+cd $DA/$TESTDIR_L
+echo "################################################################"
+echo "PWD "$PWD
+echo datalad save -m "add test job dirs and scripts"
+datalad save -m "add test job dirs and scripts"
+echo "################################################################"
+cd $HERE
 
 echo "Schedule jobs:"
 echo "num_jobs time">timing_schedule.txt
 echo "num_jobs time">timing_slurm.txt
-#echo "num_jobs time">timing_finish-list.txt
+echo "num_jobs time">timing_schedule_alt.txt
 for i in $TARGETS ; do
 
     M=$(($i%30))
     DIR="$M/test_09_output_dir_$i"
-    mkdir -p $DIR.datalad $DIR.slurm
 
     EXTRAOUT=""
     for e in `seq $NUMOUTEXTRA`; do
@@ -125,17 +156,38 @@ for i in $TARGETS ; do
         EXTRAOUT=$EXTRAOUT" -o IDONTEXIST$e/test_09_output_dir_$i/test$e.txt"
     done
 
-    echo "    running: datalad slurm-schedule -o $DIR.datalad $EXTRAOUT sbatch --chdir $DIR.datalad slurm.sh"
 
-    echo -n $i" ">>timing_schedule.txt
-    /usr/bin/time -f "%e" -o timing_schedule.txt -a datalad slurm-schedule -o $DIR.datalad $EXTRAOUT sbatch --chdir $DIR.datalad slurm.sh
+    # regular datalad schedule
+
+    cd $TESTDIR_D
+    echo "    running: datalad slurm-schedule -i $DIR/slurm.sh -o $DIR $EXTRAOUT sbatch --chdir $DIR slurm.sh"
+    echo -n $i" ">>../timing_schedule.txt
+    /usr/bin/time -f "%e" -o ../timing_schedule.txt -a datalad slurm-schedule -i $DIR/slurm.sh -o $DIR $EXTRAOUT sbatch --chdir $DIR slurm.sh
+    cd $HERE
 
     sleep 0.5s
 
-    echo -n $i" ">>timing_slurm.txt
-    /usr/bin/time -f "%e" -o timing_slurm.txt -a sbatch --chdir $DIR.slurm slurm.sh
+
+    # basic slurm submit
+
+    cd $TESTDIR_S
+    echo -n $i" ">>../timing_slurm.txt
+    /usr/bin/time -f "%e" -o ../timing_slurm.txt -a sbatch --chdir $DIR slurm.sh
+    cd $HERE
 
     sleep 0.5s
+
+
+    # datalad schedule with --alt-dir
+
+    cd $DA/$TESTDIR_L
+    echo "    running: datalad slurm-schedule -i $DIR/slurm.sh -o $DIR $EXTRAOUT --alt-dir $HERE/$TESTDIR_L sbatch --chdir $DIR slurm.sh"
+    echo -n $i" ">>$HERE/timing_schedule_alt.txt
+    /usr/bin/time -f "%e" -o $HERE/timing_schedule_alt.txt -a datalad slurm-schedule -i $DIR/slurm.sh -o $DIR $EXTRAOUT --alt-dir $HERE/$TESTDIR_L sbatch --chdir $DIR slurm.sh
+    cd $HERE
+
+    sleep 0.5s
+
 
     if [[ 0 == $M ]]; then
         while [[ 100 -lt `squeue -u $USER | grep "DLtest09" | wc -l` ]] ; do
@@ -152,13 +204,6 @@ for i in $TARGETS ; do
 
         echo "    ... continue with "`squeue -u $USER | grep "DLtest09" | wc -l`
     fi
-
-    ## run this only every 100 rounds
-    ## disabled because it gets very slow after 1000 jobs or so
-    #if [[ 0 == $M ]]; then
-    #    echo -n $i" ">>timing_finish-list.txt
-    #    /usr/bin/time -f "%e" -o timing_finish-list.txt -a datalad slurm-finish --list-open-jobs
-    #fi
 done
 
 echo "finished scheduling, now wait for all the jobs to complete" 
@@ -177,16 +222,49 @@ done
 
 echo "done waiting" 
 
+
+## finsih all jobs in $TESTDIR_D
+
+cd $TESTDIR_D
+
 echo "get all job ids"
-/usr/bin/time -f "%e" -o timing_finish_list.txt -a datalad slurm-finish --list-open-jobs | tee list_of_jobs.txt
+/usr/bin/time -f "%e" -o ../timing_finish_list.txt -a datalad slurm-finish --list-open-jobs | tee $HERE/list_of_jobs_normal.txt
 
 
 echo "finishing completed jobs:"
+echo "num_jobs time">../timing_finish.txt
 num=0
-for id in `cat list_of_jobs.txt | grep COMPLETED  |awk '{print $1}'`; do 
+for id in `cat $HERE/list_of_jobs_normal.txt | grep COMPLETED  |awk '{print $1}'`; do 
 
-    echo -n $num" ">>timing_finish.txt
-    /usr/bin/time -f "%e" -o timing_finish.txt -a datalad slurm-finish --slurm-job-id $id
+    echo -n $num" ">>../timing_finish.txt
+    /usr/bin/time -f "%e" -o ../timing_finish.txt -a datalad slurm-finish --slurm-job-id $id
 
     let num=num+1
 done
+
+cd $HERE
+
+
+## finsih all jobs in $TESTDIR_L
+
+cd $DA/$TESTDIR_L
+
+echo "get all job ids"
+/usr/bin/time -f "%e" -o $HERE/timing_finish_list_alt.txt -a datalad slurm-finish --list-open-jobs | tee $HERE/list_of_jobs_alt.txt
+
+
+echo "finishing completed jobs:"
+echo "num_jobs time">$HERE/timing_finish_alt.txt
+num=0
+for id in `cat $HERE/list_of_jobs_alt.txt | grep COMPLETED  |awk '{print $1}'`; do 
+
+    echo -n $num" ">>$HERE/timing_finish_alt.txt
+    /usr/bin/time -f "%e" -o $HERE/timing_finish_alt.txt -a datalad slurm-finish --slurm-job-id $id
+
+    let num=num+1
+done
+
+cd $HERE
+
+echo ""
+echo "done"

--- a/tests/test_13_alt_dir.sh
+++ b/tests/test_13_alt_dir.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -e # abort on errors
+
+# Test datalad 'slurm-schedule' and 'slurm-finish' functionality
+#   - create some job dirs and job scripts and 'commit' them
+#   - then 'datalad slurm-schedule' all jobs from their job dirs
+#   - wait until all of them are finished, then run 'datalad slurm-finish'
+#
+# Expected results: should run without any errors
+
+if [[ -z $1 ]] ; then
+
+    echo "no temporary directory for test repository given, abort"
+    echo ""
+    echo "... call as $0 <test-dir> <alt-dir>"
+
+    exit -1
+fi
+
+D=$1
+
+if [[ -z $2 ]] ; then
+
+    echo "no alternative directory for test repository given, abort"
+    echo ""
+    echo "... call as $0 <test-dir> <alt-dir>"
+
+    exit -1
+fi
+
+A=$2
+
+echo "repository in $D and alternative directory in $A"
+
+
+## create a test repo
+
+TESTDIR=$D/"datalad-slurm-test-13_"`date -Is|tr -d ":"`
+
+datalad create -c text2git $TESTDIR
+
+
+### generic part for all the tests ending here, specific parts follow ###
+
+# make the slurm batch script
+
+if [ ! -f "slurm_config.txt" ]; then
+    echo "Error: slurm_config.txt must exist"
+    echo "Please see slurm_config_sample.txt for a template"
+    exit -1
+fi
+
+source slurm_config.txt
+
+# Create the script
+cat << EOF > $TESTDIR/slurm.template.sh
+#!/bin/bash
+#SBATCH --job-name="DLtest13"         # name of the job
+#SBATCH --partition=$partition        
+#SBATCH -A $account
+#SBATCH --time=0:05:00                # walltime (up to 96 hours)
+#SBATCH --ntasks=1                    # number of nodes
+#SBATCH --cpus-per-task=1             # number of tasks per node
+#SBATCH --output=log.slurm-%j.out
+echo "started"
+OUTPUT="output_test.txt"
+# simulate some text output
+for i in \`seq 1 10\`; do
+    echo \$i | tee -a \$OUTPUT
+    sleep 1s
+done
+# simulate some binary output which will become an annex file
+bzip2 -k \$OUTPUT
+echo "ended"
+EOF
+
+# Make the script executable
+chmod u+x $TESTDIR/slurm.template.sh
+
+cd $TESTDIR
+
+TARGETS=`seq 17 17`
+
+for i in $TARGETS ; do
+
+    DIR="test_13_output_dir_"$i
+    mkdir -p $DIR
+
+    cp slurm.template.sh $DIR/slurm.sh
+    echo "aaa">$DIR/aaa.txt
+    mkdir -p $DIR/bbb
+    echo "ccc">$DIR/bbb/ccc.txt
+    mkdir -p $DIR/ddd/eee
+    echo "fff">$DIR/ddd/eee/fff.txt
+    mkdir -p $DIR/ggg/hhh/iii/
+    echo "jjj">$DIR/ggg/hhh/iii/jjj.txt
+    mkdir -p $DIR/kkk/lll/mmm/
+    echo "nnn">$DIR/kkk/lll/mmm/nnn.txt
+
+done
+
+datalad save -m "add test job dirs and scripts"
+
+for i in $TARGETS ; do
+
+    DIR="test_13_output_dir_"$i
+
+    cd $DIR
+    datalad slurm-schedule -i slurm.sh -i aaa.txt -i bbb/ccc.txt -i ddd/eee/fff.txt -i ggg/hhh/iii -i kkk/lll/mmm/ -o output_test.txt -o output_test.txt.bz2 --alt-dir $A sbatch slurm.sh
+    cd ..
+
+done
+
+while [[ 0 != `squeue -u $USER | grep "DLtest13" | wc -l` ]] ; do
+
+    echo "    ... wait for jobs to finish"
+    sleep 1m
+done
+
+datalad slurm-finish --list-open-jobs
+
+echo "finishing completed jobs:"
+echo "    "$PWD
+datalad slurm-finish
+
+#echo " ### git log in this repo ### "
+#echo ""
+#git log
+
+
+


### PR DESCRIPTION
Allow to specify an alternative run directory for the job. Then the job's inputs are copied there, the job is run from there, and at slurm-finish time all outputs are copied back to the repository. 

Then the repository can stay on a local file system while the alternative run directory is on a parallel file system (like GPFS or Lustre) where Slurm can run it on any compute node. This will make datalad resp. git operations much, much faster.
